### PR TITLE
make this work with Alien::Base 0.005

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,3 +7,4 @@ copyright_year   = 2013
 [@Author::GETTY]
 alien_repo = http://ffmpeg.org/releases
 alien_bins = ffmpeg ffprobe ffserver
+alien_autoconf_with_pic = 0


### PR DESCRIPTION
Hi there,

The next version of `Alien::Base` will default to using `--with-pic` when it runs `configure`.  This is normally what you want as it will create position independent code when building static libraries, which is necessary on some platforms when creating XS extensions with static Alien libraries.  Usually if autotools does nopt support this option it simply ignores it.  Unfortunately `ffmpeg` has a configure script which is not based on autotools and so it fails when it sees this option.  With this minor change, and other PR:

https://github.com/Getty/p5-dist-zilla-pluginbundle-author-getty/pull/2

it should work with the new version of `Alien::Base` when it is released to CPAN.  If you are interested, here is a RC for the next version:

https://metacpan.org/pod/release/PLICEASE/Alien-Base-0.004_05/lib/Alien/Base.pm
